### PR TITLE
Add script to capture CSS animation screenshot using Playwright

### DIFF
--- a/scripts/capture-css-animation.js
+++ b/scripts/capture-css-animation.js
@@ -1,0 +1,38 @@
+const { chromium } = require('playwright');
+const path = require('path');
+
+(async () => {
+  const browser = await chromium.launch();
+  const context = await browser.newContext({
+    viewport: { width: 320, height: 240 },
+  });
+  const page = await context.newPage();
+
+  const targetPath = path.resolve(__dirname, '..', 'assets', 'example', 'css-animation.html');
+  const fileUrl = `file://${targetPath}`;
+  await page.goto(fileUrl);
+
+  const client = await context.newCDPSession(page);
+
+  await client.send('Emulation.setVirtualTimePolicy', {
+    policy: 'pauseIfNetworkFetchesPending',
+    budget: 0,
+  });
+
+  const budgetExpired = new Promise((resolve) =>
+    client.once('Emulation.virtualTimeBudgetExpired', resolve)
+  );
+
+  await client.send('Emulation.setVirtualTimePolicy', {
+    policy: 'pauseIfNetworkFetchesPending',
+    budget: 4000,
+  });
+
+  await budgetExpired;
+
+  await page.screenshot({
+    path: path.resolve(__dirname, '..', 'assets', 'example', 'css-animation-4s.png'),
+  });
+
+  await browser.close();
+})();


### PR DESCRIPTION
## Summary
- add a Playwright helper script that opens the CSS animation example and uses Chrome DevTools virtual time to jump forward
- capture a screenshot of the 4-second state into the assets/example directory

## Testing
- not run (Playwright dependency not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68dd3f5d2594832b9167333369bed0f9