### PR TITLE
Update CSS animation capture output handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Dependencies
 node_modules/
 bower_components/
+package-lock.json
 
 # Logs
 npm-debug.log*
@@ -48,4 +49,4 @@ Thumbs.db
 *.swp
 
 # Generated assets
-assets/example/css-animation-4s.png
+tmp/output/

--- a/README.md
+++ b/README.md
@@ -23,6 +23,6 @@ Follow these steps to configure your environment and run the script:
    ```bash
    npm run capture:css-animation
    ```
-   The screenshot will be written to `assets/example/css-animation-4s.png`.
+   The screenshot will be written to `tmp/output/css-animation-4s.png`.
 
 If you are running in a minimal Linux environment, you may also need system libraries required by Chromium. Playwright documents the list of packages for each distribution in its [installation guide](https://playwright.dev/docs/intro#system-requirements).

--- a/scripts/capture-css-animation.js
+++ b/scripts/capture-css-animation.js
@@ -1,4 +1,5 @@
 const { chromium } = require('playwright');
+const fs = require('fs/promises');
 const path = require('path');
 
 (async () => {
@@ -30,8 +31,17 @@ const path = require('path');
 
   await budgetExpired;
 
+  const screenshotPath = path.resolve(
+    __dirname,
+    '..',
+    'tmp',
+    'output',
+    'css-animation-4s.png'
+  );
+  await fs.mkdir(path.dirname(screenshotPath), { recursive: true });
+
   await page.screenshot({
-    path: path.resolve(__dirname, '..', 'assets', 'example', 'css-animation-4s.png'),
+    path: screenshotPath,
   });
 
   await browser.close();


### PR DESCRIPTION
## Summary
- update the CSS animation capture script to save its screenshot under tmp/output and ensure the folder exists
- document the new screenshot location and ignore the generated output directory and package-lock.json

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd44df40bc832bbaa9c822a2895bcf