### PR TITLE
fix: capture animation screenshots at 4 seconds

### DIFF
--- a/scripts/capture-animation-screenshot.js
+++ b/scripts/capture-animation-screenshot.js
@@ -21,6 +21,8 @@ const targetPath = path.resolve(
   animationFile
 );
 
+const TARGET_TIME_MS = 4_000;
+
 (async () => {
   try {
     await fs.access(targetPath);
@@ -45,16 +47,12 @@ const targetPath = path.resolve(
     budget: 0,
   });
 
-  const budgetExpired = new Promise((resolve) =>
-    client.once('Emulation.virtualTimeBudgetExpired', resolve)
-  );
-
   await client.send('Emulation.setVirtualTimePolicy', {
     policy: 'pauseIfNetworkFetchesPending',
-    budget: 4000,
+    budget: TARGET_TIME_MS,
   });
 
-  await budgetExpired;
+  await page.waitForTimeout(1000);
 
   // Force CSS animations to their state at the 4-second mark. Some animations
   // keep running indefinitely which can prevent the visual state from ever
@@ -98,13 +96,14 @@ const targetPath = path.resolve(
         set() {},
       });
     }
-  }, 4000);
+  }, TARGET_TIME_MS);
 
   const safeName = animationFile
     .replace(/[\\/]/g, '-')
     .replace(/\.html?$/i, '')
     .trim();
-  const screenshotFilename = `${safeName || 'animation'}-4s.png`;
+  const targetSeconds = Math.round(TARGET_TIME_MS / 1000);
+  const screenshotFilename = `${safeName || 'animation'}-${targetSeconds}s.png`;
   const screenshotPath = path.resolve(
     __dirname,
     '..',


### PR DESCRIPTION
## Summary
- update the capture script to fast-forward virtual time to 4 seconds and adjust comments
- refresh the README to document the 4-second capture timing and filename suffix

## Testing
- npx playwright install chromium
- npx playwright install-deps chromium
- npm run capture:animation -- css-animation.html

------
https://chatgpt.com/codex/tasks/task_e_68dd519c4350832bb2b4b81e301feeb4