### PR TITLE
docs: clarify language requirements

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,14 @@ These instructions apply to the entire repository.
 - Document in your testing summary which of the above commands were executed (or why they were not required).
 
 ## Documentation
+- Keep all documentation written entirely in English.
 - Update `README.md` whenever you change how contributors configure or run the capture workflow, or when defaults such as the fast-forward timestamp or output paths change.
+
+## Code Comments
+- Write all code comments in English.
+
+## Communication
+- When responding to user questions or requests, reply using the language used in the user's input.
 
 ## Git and PRs
 - Use Conventional Commits for commit messages (e.g., `feat: ...`, `fix: ...`).


### PR DESCRIPTION
## Summary
- document that all repository documentation must remain in English
- add guidance to write code comments in English and to reply in the user's language

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de51419f2c832ba07478ecf5e4d8b3