### PR TITLE
fix: clamp example animations at four seconds

### DIFF
--- a/assets/example/animejs-virtual-time.html
+++ b/assets/example/animejs-virtual-time.html
@@ -89,6 +89,8 @@
 
     <script src="./anime32.min.js"></script>
     <script>
+      const STOP_AT_MS = 4000;
+
       const tl = anime.timeline({
         easing: "easeOutQuad",
       });
@@ -120,7 +122,15 @@
         }
 
         const tick = () => {
-          updateRafTimestamp(performance.now() - timestampStart);
+          const elapsed = performance.now() - timestampStart;
+          updateRafTimestamp(elapsed);
+
+          if (elapsed >= STOP_AT_MS) {
+            cancelAnimationFrame(timestampAnimationFrameId);
+            timestampAnimationFrameId = null;
+            return;
+          }
+
           timestampAnimationFrameId = requestAnimationFrame(tick);
         };
 
@@ -137,7 +147,9 @@
       }
 
       function updateRafTimestamp(milliseconds) {
-        timestampRafElement.textContent = formatElapsedTime(milliseconds);
+        timestampRafElement.textContent = formatElapsedTime(
+          Math.min(milliseconds, STOP_AT_MS)
+        );
       }
 
       function getChromeVersion() {
@@ -163,6 +175,10 @@
       startFun();
 
       startTimestampTicker();
+      setTimeout(() => {
+        tl.pause();
+        tl.seek(STOP_AT_MS);
+      }, STOP_AT_MS);
 
       async function renderMain() {
         // show page

--- a/assets/example/canvas-orbit-virtual-time.html
+++ b/assets/example/canvas-orbit-virtual-time.html
@@ -59,6 +59,8 @@
       <div id="caption">ORBITAL PLAYGROUND</div>
     </div>
     <script>
+      const STOP_AT_MS = 4000;
+
       const canvas = document.getElementById("universe");
       const ctx = canvas.getContext("2d");
       const timestampElement = document.getElementById("timestampRaf");
@@ -77,7 +79,14 @@
 
       function updateTimestamp() {
         const elapsed = performance.now() - startTime;
-        timestampElement.textContent = formatElapsedTime(elapsed);
+        timestampElement.textContent = formatElapsedTime(
+          Math.min(elapsed, STOP_AT_MS)
+        );
+
+        if (elapsed >= STOP_AT_MS) {
+          return;
+        }
+
         requestAnimationFrame(updateTimestamp);
       }
 
@@ -167,10 +176,15 @@
       }
 
       function render() {
-        const elapsed = performance.now() - startTime;
+        const elapsed = Math.min(performance.now() - startTime, STOP_AT_MS);
         drawBackground(elapsed);
         drawStar(elapsed);
         drawPlanets(elapsed);
+
+        if (elapsed >= STOP_AT_MS) {
+          return;
+        }
+
         requestAnimationFrame(render);
       }
 

--- a/assets/example/css-animation.html
+++ b/assets/example/css-animation.html
@@ -55,7 +55,7 @@
         border-radius: 50%;
         filter: blur(40px);
         opacity: 0;
-        animation: haloPulse 6s ease-in-out infinite;
+        animation: haloPulse 4s ease-in-out forwards;
       }
       #content {
         position: relative;
@@ -157,8 +157,7 @@
       }
 
       @keyframes haloPulse {
-        0%,
-        100% {
+        0% {
           opacity: 0;
           transform: scale(0.9) rotate(0deg);
         }
@@ -167,6 +166,10 @@
           transform: scale(1.05) rotate(35deg);
         }
         70% {
+          opacity: 0.4;
+          transform: scale(1) rotate(60deg);
+        }
+        100% {
           opacity: 0.4;
           transform: scale(1) rotate(60deg);
         }
@@ -188,6 +191,8 @@
     </div>
 
     <script>
+      const STOP_AT_MS = 4000;
+
       // Updates the timestamp to reflect elapsed milliseconds using rAF.
       const timestampElement = document.getElementById("timestampRaf");
 
@@ -204,7 +209,13 @@
 
       function updateTimestamp() {
         const elapsed = performance.now() - startTime;
-        timestampElement.textContent = formatElapsedTime(elapsed);
+        timestampElement.textContent = formatElapsedTime(
+          Math.min(elapsed, STOP_AT_MS)
+        );
+        if (elapsed >= STOP_AT_MS) {
+          return;
+        }
+
         requestAnimationFrame(updateTimestamp);
       }
 

--- a/assets/example/web-animations-virtual-time.html
+++ b/assets/example/web-animations-virtual-time.html
@@ -69,6 +69,8 @@
       <div id="timeLabel">00:00.000</div>
     </div>
     <script>
+      const STOP_AT_MS = 4000;
+
       const ball = document.querySelector(".ball");
       const trailContainer = document.querySelector(".trail");
       const timeLabel = document.getElementById("timeLabel");
@@ -87,7 +89,12 @@
 
       function updateTimestamp() {
         const elapsed = performance.now() - startTime;
-        timeLabel.textContent = formatElapsedTime(elapsed);
+        timeLabel.textContent = formatElapsedTime(Math.min(elapsed, STOP_AT_MS));
+
+        if (elapsed >= STOP_AT_MS) {
+          return;
+        }
+
         requestAnimationFrame(updateTimestamp);
       }
 
@@ -110,9 +117,10 @@
       ];
 
       const ballAnimation = ball.animate(travelPath, {
-        duration: 4000,
+        duration: STOP_AT_MS,
         easing: "ease-in-out",
-        iterations: Infinity,
+        iterations: 1,
+        fill: "forwards",
       });
 
       const colorAnimation = ball.animate(
@@ -123,8 +131,9 @@
           { filter: "hue-rotate(360deg) saturate(140%)" },
         ],
         {
-          duration: 4000,
-          iterations: Infinity,
+          duration: STOP_AT_MS,
+          iterations: 1,
+          fill: "forwards",
         }
       );
 
@@ -138,7 +147,8 @@
           {
             duration: 1600,
             delay: index * 60,
-            iterations: Infinity,
+            iterations: 1,
+            fill: "forwards",
             easing: "ease-in-out",
           }
         )
@@ -149,6 +159,12 @@
       tilesAnimation.forEach((animation) => {
         animation.startTime = ballAnimation.startTime;
       });
+
+      setTimeout(() => {
+        ballAnimation.finish();
+        colorAnimation.finish();
+        tilesAnimation.forEach((animation) => animation.finish());
+      }, STOP_AT_MS);
     </script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- clamp the CSS showcase animation and timestamp so the scene freezes at four seconds
- stop the anime.js timeline and timestamp ticker once it reaches the four-second mark
- update the web animations and canvas demos to finish and hold their final frame at four seconds

## Testing
- npm run capture:animation *(fails: Playwright Chromium binary not found. Run `npx playwright install chromium` and retry.)*

------
https://chatgpt.com/codex/tasks/task_e_68de7497a5b8832bb9a275bb1cc6b74c