### PR TITLE
feat: add incremental animation capture script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 This repository contains small web examples and automation helpers.
 
-## Running the animation capture script
+## Running the animation capture scripts
 
-The `scripts/capture-animation-screenshot.js` script uses [Playwright](https://playwright.dev/) and Chrome DevTools Protocol virtual time to jump to the 4-second mark of any HTML animation example under `assets/example/` and save a screenshot.
+The `scripts/capture-animation-screenshot.js` script uses [Playwright](https://playwright.dev/) and Chrome DevTools Protocol virtual time to jump to the 4-second mark of any HTML animation example under `assets/example/` and save a screenshot. An alternative implementation, `scripts/capture-animation-screenshot-incremental.js`, advances virtual time in smaller steps before taking the same 4-second capture.
 
 Follow these steps to configure your environment and run the script:
 
@@ -29,6 +29,13 @@ Follow these steps to configure your environment and run the script:
    npm run capture:animation
    ```
    The script automatically iterates over every HTML example in `assets/example/` and writes screenshots to `tmp/output/<animation-name>-4s.png`.
+
+   To run the incremental stepping variant instead, execute:
+
+   ```bash
+   npm run capture:animation:incremental
+   ```
+   This version gradually progresses virtual time in 250 ms slices before taking the 4-second screenshot, which can help when animations rely on incremental state updates.
 
 If `playwright install-deps` is not available on your platform, refer to the list of packages documented in Playwright's [system requirements guide](https://playwright.dev/docs/intro#system-requirements).
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Playwright helper scripts for the code-play examples",
   "private": true,
   "scripts": {
-    "capture:animation": "node scripts/capture-animation-screenshot.js"
+    "capture:animation": "node scripts/capture-animation-screenshot.js",
+    "capture:animation:incremental": "node scripts/capture-animation-screenshot-incremental.js"
   },
   "dependencies": {
     "playwright": "^1.43.0"

--- a/scripts/capture-animation-screenshot-incremental.js
+++ b/scripts/capture-animation-screenshot-incremental.js
@@ -1,0 +1,183 @@
+const { chromium } = require('playwright');
+const fs = require('fs/promises');
+const path = require('path');
+const { pathToFileURL } = require('url');
+
+const TARGET_TIME_MS = 4_000;
+const VIRTUAL_TIME_STEP_MS = 250;
+const EXAMPLE_DIR = path.resolve(__dirname, '..', 'assets', 'example');
+const OUTPUT_DIR = path.resolve(__dirname, '..', 'tmp', 'output');
+const VIEWPORT_DIMENSIONS = { width: 320, height: 240 };
+const POST_VIRTUAL_TIME_WAIT_MS = 1_000;
+const HTML_FILE_PATTERN = /\.html?$/i;
+
+async function ensureDirectoryAvailable(directoryPath) {
+  try {
+    await fs.access(directoryPath);
+  } catch (error) {
+    if (error?.code === 'ENOENT') {
+      throw new Error(
+        `Expected directory "${directoryPath}" to exist. Add animation examples under assets/example/.`
+      );
+    }
+
+    throw error;
+  }
+}
+
+async function collectAnimationFiles(directoryPath) {
+  const entries = await fs.readdir(directoryPath, { withFileTypes: true });
+
+  return entries
+    .filter((entry) => entry.isFile() && HTML_FILE_PATTERN.test(entry.name))
+    .map((entry) => entry.name)
+    .sort((a, b) => a.localeCompare(b));
+}
+
+async function advanceVirtualTime(client, budgetMs) {
+  return new Promise((resolve, reject) => {
+    const handleBudgetExpired = () => resolve();
+
+    client.once('Emulation.virtualTimeBudgetExpired', handleBudgetExpired);
+
+    client
+      .send('Emulation.setVirtualTimePolicy', {
+        policy: 'pauseIfNetworkFetchesPending',
+        budget: budgetMs,
+      })
+      .catch((error) => {
+        client.off('Emulation.virtualTimeBudgetExpired', handleBudgetExpired);
+        reject(error);
+      });
+  });
+}
+
+async function captureAnimationFile(browser, animationFile) {
+  const targetPath = path.resolve(EXAMPLE_DIR, animationFile);
+  const context = await browser.newContext({ viewport: VIEWPORT_DIMENSIONS });
+  const page = await context.newPage();
+
+  try {
+    const fileUrl = pathToFileURL(targetPath).href;
+    await page.goto(fileUrl, { waitUntil: 'load' });
+
+    const client = await context.newCDPSession(page);
+
+    await client.send('Emulation.setVirtualTimePolicy', {
+      policy: 'pauseIfNetworkFetchesPending',
+      budget: 0,
+    });
+
+    let elapsed = 0;
+    while (elapsed < TARGET_TIME_MS) {
+      const remaining = TARGET_TIME_MS - elapsed;
+      const step = Math.min(remaining, VIRTUAL_TIME_STEP_MS);
+      await advanceVirtualTime(client, step);
+      elapsed += step;
+    }
+
+    await page.waitForTimeout(POST_VIRTUAL_TIME_WAIT_MS);
+
+    await page.evaluate((targetTimeMs) => {
+      const animations = document.getAnimations();
+      for (const animation of animations) {
+        try {
+          animation.currentTime = targetTimeMs;
+          animation.pause();
+        } catch (error) {
+          console.warn('Failed to fast-forward animation', error);
+        }
+      }
+    }, TARGET_TIME_MS);
+
+    const safeName = animationFile
+      .replace(/[\\/]/g, '-')
+      .replace(HTML_FILE_PATTERN, '')
+      .trim();
+    const targetSeconds = Math.round(TARGET_TIME_MS / 1000);
+    const screenshotFilename = `${safeName || 'animation'}-${targetSeconds}s.png`;
+    const screenshotPath = path.resolve(OUTPUT_DIR, screenshotFilename);
+
+    await page.screenshot({ path: screenshotPath });
+
+    return screenshotPath;
+  } finally {
+    await context.close();
+  }
+}
+
+function logChromiumLaunchFailure(error) {
+  const message = error?.message || '';
+
+  if (message.includes("Executable doesn't exist")) {
+    console.error(
+      'Playwright Chromium binary not found. Run "npx playwright install chromium" and retry.'
+    );
+  } else if (message.includes('Host system is missing dependencies')) {
+    console.error(
+      'Chromium is missing required system libraries. Install them with "npx playwright install-deps" (or consult Playwright\'s documentation for your platform) and retry.'
+    );
+  } else {
+    console.error('Failed to launch Chromium:', error);
+  }
+}
+
+(async () => {
+  try {
+    await ensureDirectoryAvailable(EXAMPLE_DIR);
+  } catch (error) {
+    console.error(error.message);
+    process.exitCode = 1;
+    return;
+  }
+
+  let animationFiles;
+  try {
+    animationFiles = await collectAnimationFiles(EXAMPLE_DIR);
+  } catch (error) {
+    console.error('Unable to read animation examples:', error);
+    process.exitCode = 1;
+    return;
+  }
+
+  if (animationFiles.length === 0) {
+    console.error('No animation HTML files found in assets/example');
+    process.exitCode = 1;
+    return;
+  }
+
+  await fs.mkdir(OUTPUT_DIR, { recursive: true });
+
+  let browser;
+  try {
+    browser = await chromium.launch();
+  } catch (error) {
+    logChromiumLaunchFailure(error);
+    process.exitCode = 1;
+    return;
+  }
+
+  const failures = [];
+
+  try {
+    for (const animationFile of animationFiles) {
+      try {
+        const screenshotPath = await captureAnimationFile(browser, animationFile);
+        console.log(`Captured ${animationFile} -> ${screenshotPath}`);
+      } catch (error) {
+        failures.push(animationFile);
+        console.error(`Failed to capture ${animationFile}:`, error);
+      }
+    }
+  } finally {
+    await browser.close();
+  }
+
+  if (failures.length > 0) {
+    console.error(
+      `Encountered errors while capturing ${failures.length} animation(s): ${failures.join(', ')}`
+    );
+    process.exitCode = 1;
+  }
+})();
+


### PR DESCRIPTION
## Summary
- add an alternative capture script that advances virtual time in smaller steps before taking screenshots
- reuse the same general-purpose automation flow with incremental seeking
- document the incremental workflow and expose it via an npm script alias

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de778be584832bb66f5e2004918da9