### PR TITLE
fix: align video autoplay timestamp with elapsed time

### DIFF
--- a/assets/example/video-autoplay.html
+++ b/assets/example/video-autoplay.html
@@ -100,6 +100,7 @@
       const START_DELAY_MS = 1000;
       const STOP_AT_SECONDS = 4;
       const STOP_AT_MILLISECONDS = STOP_AT_SECONDS * 1000;
+      const PLAYBACK_STOP_SECONDS = 3;
 
       const video = document.getElementById("catVideo");
       const timestampElement = document.getElementById("timestampRaf");
@@ -125,7 +126,6 @@
 
         hasStopped = true;
         video.pause();
-        video.currentTime = STOP_AT_SECONDS;
         timestampElement.textContent = formatElapsedTime(STOP_AT_MILLISECONDS);
         cancelAnimation();
       }
@@ -190,7 +190,7 @@
       }
 
       video.addEventListener("timeupdate", () => {
-        if (video.currentTime >= STOP_AT_SECONDS) {
+        if (video.currentTime >= PLAYBACK_STOP_SECONDS) {
           finalizeStop();
         }
       });

--- a/assets/example/video-autoplay.html
+++ b/assets/example/video-autoplay.html
@@ -64,7 +64,13 @@
         border-radius: 12px;
         overflow: hidden;
         box-shadow: 0 16px 32px rgba(15, 23, 42, 0.4);
-        background: rgba(15, 23, 42, 0.4);
+        background:
+          radial-gradient(
+            circle at 30% 30%,
+            rgba(148, 163, 184, 0.55),
+            rgba(30, 64, 175, 0.4)
+          ),
+          rgba(15, 23, 42, 0.25);
       }
 
       video {

--- a/assets/example/video-autoplay.html
+++ b/assets/example/video-autoplay.html
@@ -72,6 +72,12 @@
         width: 100%;
         height: 100%;
         object-fit: cover;
+        opacity: 0;
+        transition: opacity 1s ease;
+      }
+
+      video.is-visible {
+        opacity: 1;
       }
 
       p {
@@ -86,7 +92,7 @@
   <body>
     <div id="pages">
       <div id="timestampRaf">00:00.000</div>
-      <h1>Cat Loop</h1>
+      <h1>VIDEO TEST</h1>
       <div class="video-frame">
         <video id="catVideo" muted playsinline preload="auto">
           <source src="video/test_video_cat.mp4" type="video/mp4" />
@@ -166,12 +172,15 @@
         hasStopped = false;
         startTimer();
 
+        video.classList.remove("is-visible");
+
         if (startTimeoutId !== null) {
           clearTimeout(startTimeoutId);
         }
 
         startTimeoutId = window.setTimeout(() => {
           startTimeoutId = null;
+          video.classList.add("is-visible");
           video.play().catch(() => {
             // Intentionally left empty: autoplay might require user interaction in some browsers.
           });

--- a/assets/example/video-autoplay.html
+++ b/assets/example/video-autoplay.html
@@ -118,6 +118,18 @@
         return `${minutes}:${seconds}.${ms}`;
       }
 
+      function finalizeStop() {
+        if (hasStopped) {
+          return;
+        }
+
+        hasStopped = true;
+        video.pause();
+        video.currentTime = STOP_AT_SECONDS;
+        timestampElement.textContent = formatElapsedTime(STOP_AT_MILLISECONDS);
+        cancelAnimation();
+      }
+
       function tick(now) {
         if (timerStartTimestamp === null) {
           timerStartTimestamp = now;
@@ -126,8 +138,7 @@
         const elapsedMilliseconds = now - timerStartTimestamp;
 
         if (elapsedMilliseconds >= STOP_AT_MILLISECONDS) {
-          timestampElement.textContent = formatElapsedTime(STOP_AT_MILLISECONDS);
-          cancelAnimation();
+          finalizeStop();
           return;
         }
 
@@ -179,12 +190,8 @@
       }
 
       video.addEventListener("timeupdate", () => {
-        if (!hasStopped && video.currentTime >= STOP_AT_SECONDS) {
-          hasStopped = true;
-          video.currentTime = STOP_AT_SECONDS;
-          video.pause();
-          timestampElement.textContent = formatElapsedTime(STOP_AT_MILLISECONDS);
-          cancelAnimation();
+        if (video.currentTime >= STOP_AT_SECONDS) {
+          finalizeStop();
         }
       });
     </script>

--- a/assets/example/video-autoplay.html
+++ b/assets/example/video-autoplay.html
@@ -99,6 +99,7 @@
     <script>
       const START_DELAY_MS = 1000;
       const STOP_AT_SECONDS = 4;
+      const STOP_AT_MILLISECONDS = STOP_AT_SECONDS * 1000;
 
       const video = document.getElementById("catVideo");
       const timestampElement = document.getElementById("timestampRaf");
@@ -106,6 +107,7 @@
       let startTimeoutId = null;
       let rafId = null;
       let hasStopped = false;
+      let timerStartTimestamp = null;
 
       function formatElapsedTime(milliseconds) {
         const totalMilliseconds = Math.max(0, Math.floor(milliseconds));
@@ -116,13 +118,28 @@
         return `${minutes}:${seconds}.${ms}`;
       }
 
-      function updateTimestamp() {
-        const elapsedSeconds = Math.min(video.currentTime, STOP_AT_SECONDS);
-        timestampElement.textContent = formatElapsedTime(elapsedSeconds * 1000);
-
-        if (!video.paused && !video.ended && !hasStopped) {
-          rafId = requestAnimationFrame(updateTimestamp);
+      function tick(now) {
+        if (timerStartTimestamp === null) {
+          timerStartTimestamp = now;
         }
+
+        const elapsedMilliseconds = now - timerStartTimestamp;
+
+        if (elapsedMilliseconds >= STOP_AT_MILLISECONDS) {
+          timestampElement.textContent = formatElapsedTime(STOP_AT_MILLISECONDS);
+          cancelAnimation();
+          return;
+        }
+
+        timestampElement.textContent = formatElapsedTime(elapsedMilliseconds);
+        rafId = requestAnimationFrame(tick);
+      }
+
+      function startTimer() {
+        cancelAnimation();
+        timerStartTimestamp = performance.now();
+        timestampElement.textContent = formatElapsedTime(0);
+        rafId = requestAnimationFrame(tick);
       }
 
       function cancelAnimation() {
@@ -136,7 +153,7 @@
         video.pause();
         video.currentTime = 0;
         hasStopped = false;
-        timestampElement.textContent = formatElapsedTime(0);
+        startTimer();
 
         if (startTimeoutId !== null) {
           clearTimeout(startTimeoutId);
@@ -161,23 +178,13 @@
         handleLoadedMetadata();
       }
 
-      video.addEventListener("play", () => {
-        hasStopped = false;
-        cancelAnimation();
-        rafId = requestAnimationFrame(updateTimestamp);
-      });
-
-      video.addEventListener("pause", () => {
-        cancelAnimation();
-        const elapsedSeconds = Math.min(video.currentTime, STOP_AT_SECONDS);
-        timestampElement.textContent = formatElapsedTime(elapsedSeconds * 1000);
-      });
-
       video.addEventListener("timeupdate", () => {
         if (!hasStopped && video.currentTime >= STOP_AT_SECONDS) {
           hasStopped = true;
           video.currentTime = STOP_AT_SECONDS;
           video.pause();
+          timestampElement.textContent = formatElapsedTime(STOP_AT_MILLISECONDS);
+          cancelAnimation();
         }
       });
     </script>


### PR DESCRIPTION
## Summary
- count the video autoplay timestamp from the start of the demo instead of the media current time
- stop the requestAnimationFrame loop at the 4 second mark when the video pauses

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68df85683878832b97f65346065d25a3