### PR TITLE
feat: allow capture script to use system chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,18 @@ Follow these steps to configure your environment and run the script:
    npx playwright install-deps
    ```
    On minimal Linux environments this installs system libraries that Chromium needs. Skip this step on macOS/Windows.
-5. **Run the capture script:**
+5. **(Optional) Tell Playwright to use a system-installed browser:**
+   * To reuse an existing Chrome or Chromium installation that Playwright knows how to launch, set `PLAYWRIGHT_BROWSER_CHANNEL`. For example:
+     ```bash
+     PLAYWRIGHT_BROWSER_CHANNEL=chrome npm run capture:animation
+     ```
+     This uses the Chrome Stable channel shipped with your operating system.
+   * To point at a specific executable path (for example a portable Chromium build), set `PLAYWRIGHT_CHROME_EXECUTABLE` instead:
+     ```bash
+     PLAYWRIGHT_CHROME_EXECUTABLE="/usr/bin/google-chrome-stable" npm run capture:animation
+     ```
+     When this variable is present the channel setting is ignored.
+6. **Run the capture script:**
    ```bash
    npm run capture:animation
    ```


### PR DESCRIPTION
## Summary
- allow the capture automation to launch a system Chrome build via environment variables
- clarify in the README how to select a Playwright browser channel or executable path
- extend launch failure messaging to highlight channel/executable misconfiguration

## Testing
- npm run capture:animation *(fails: Chromium is missing required system libraries in the container)*
- npx playwright install chromium
- npx playwright install-deps


------
https://chatgpt.com/codex/tasks/task_e_68e0d052d68c832baf106cf2632f8789