### PR TITLE
fix: align anime.js timelines with capture timestamps

### DIFF
--- a/scripts/capture-animation-screenshot.js
+++ b/scripts/capture-animation-screenshot.js
@@ -406,6 +406,21 @@ async function synchronizeAnimationState(page, targetTimeMs) {
         console.warn('Failed to invoke requestAnimationFrame callbacks directly', error);
       }
     }
+
+    const animeFactory = window.anime;
+    if (animeFactory && Array.isArray(animeFactory.running)) {
+      for (const instance of animeFactory.running) {
+        if (!instance || typeof instance.seek !== 'function') {
+          continue;
+        }
+
+        try {
+          instance.seek(targetTimeMs);
+        } catch (error) {
+          console.warn('Failed to seek anime.js instance to target time', error);
+        }
+      }
+    }
   }, targetTimeMs);
 }
 

--- a/scripts/capture-animation-screenshot.js
+++ b/scripts/capture-animation-screenshot.js
@@ -87,6 +87,13 @@ const FRAMEWORK_PATCHES = [
       automationState.animeLifecyclePatched = true;
 
       const patchedInstances = new WeakSet();
+      const trackedInstances =
+        (automationState.animeTrackedInstances ||= new Set());
+
+      automationState.getTrackedAnimeInstances = () =>
+        Array.from(trackedInstances).filter(
+          (instance) => instance && typeof instance === 'object'
+        );
 
       // Recursively decorates an anime.js instance and its children so bootstrap state is preserved after virtual seeks.
       const patchInstance = (instance) => {
@@ -95,6 +102,7 @@ const FRAMEWORK_PATCHES = [
         }
 
         patchedInstances.add(instance);
+        trackedInstances.add(instance);
 
         if (Array.isArray(instance.children)) {
           instance.children.forEach(patchInstance);
@@ -407,18 +415,23 @@ async function synchronizeAnimationState(page, targetTimeMs) {
       }
     }
 
-    const animeFactory = window.anime;
-    if (animeFactory && Array.isArray(animeFactory.running)) {
-      for (const instance of animeFactory.running) {
-        if (!instance || typeof instance.seek !== 'function') {
-          continue;
-        }
+    const trackedInstances =
+      (automationState?.getTrackedAnimeInstances?.() || [])
+        .concat(Array.isArray(window.anime?.running) ? window.anime.running : []);
 
-        try {
-          instance.seek(targetTimeMs);
-        } catch (error) {
-          console.warn('Failed to seek anime.js instance to target time', error);
-        }
+    const seen = new Set();
+
+    for (const instance of trackedInstances) {
+      if (!instance || typeof instance.seek !== 'function' || seen.has(instance)) {
+        continue;
+      }
+
+      seen.add(instance);
+
+      try {
+        instance.seek(targetTimeMs);
+      } catch (error) {
+        console.warn('Failed to seek anime.js instance to target time', error);
       }
     }
   }, targetTimeMs);


### PR DESCRIPTION
## Summary
- ensure anime.js timelines are explicitly sought to the current capture timestamp so virtual-time captures show intermediate frames

## Testing
- npx playwright install chromium
- npx playwright install-deps
- npm run capture:animation -- animejs-virtual-time.html


------
https://chatgpt.com/codex/tasks/task_e_68e2a3b66eb0832bb2d0967f6fbaef4c