### PR TITLE
chore: enforce prettier formatting for scripts

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,9 @@
+{
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "es5",
+  "printWidth": 80,
+  "tabWidth": 2,
+  "useTabs": false,
+  "arrowParens": "always"
+}

--- a/README.md
+++ b/README.md
@@ -78,3 +78,13 @@ After following the installation steps, use the commands below to confirm your e
 1. Install dependencies with `npm install`.
 2. Install the Chromium browser binary with `npx playwright install chromium` (and, on Linux, system libraries via `npx playwright install-deps`).
 3. Capture an example animation with `npm run capture:animation -- animejs-virtual-time.html`. You should see output similar to `tmp/output/animejs-virtual-time-0000ms.png` through `tmp/output/animejs-virtual-time-4000ms.png`, representing the 100 ms timeline.
+
+## Formatting scripts
+
+To keep code style consistent with the Prettier – Code formatter settings used in VS Code, run:
+
+```bash
+npm run format
+```
+
+This command applies Prettier's defaults to every file under `scripts/`, matching the formatting you would get from the VS Code extension.

--- a/package.json
+++ b/package.json
@@ -4,9 +4,13 @@
   "description": "Playwright helper scripts for the code-play examples",
   "private": true,
   "scripts": {
-    "capture:animation": "node scripts/capture-animation-screenshot.js"
+    "capture:animation": "node scripts/capture-animation-screenshot.js",
+    "format": "prettier --write \"scripts/*.js\""
   },
   "dependencies": {
     "playwright": "^1.43.0"
+  },
+  "devDependencies": {
+    "prettier": "^3.2.5"
   }
 }

--- a/scripts/capture-animation-screenshot.js
+++ b/scripts/capture-animation-screenshot.js
@@ -614,8 +614,8 @@ async function injectRafProbe(context) {
           typeof automationState.firstPerformanceNow === "number"
             ? automationState.firstPerformanceNow
             : typeof automationState.performanceNowOrigin === "number"
-            ? automationState.performanceNowOrigin
-            : 0;
+              ? automationState.performanceNowOrigin
+              : 0;
         Object.defineProperty(performance, "now", {
           configurable: true,
           value: () => origin + fixedTimestamp,


### PR DESCRIPTION
## Summary
- add a Prettier configuration that matches the VS Code Prettier defaults for the scripts directory
- expose an npm format script and document how to apply it to scripts
- run the formatter to align the existing capture script with the Prettier settings

## Testing
- npm install
- npm run format

------
https://chatgpt.com/codex/tasks/task_e_68e3749c9848832b9a926dd7f195d2fe