### PR TITLE
fix: stabilize virtual time capture helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ DOM state as a human viewer would see at the default 4-second mark.
 
 ## Running the animation capture script
 
-The repository provides `scripts/capture-animation-screenshot.js`, which uses [Playwright](https://playwright.dev/) and Chrome DevTools Protocol virtual time to jump to the default 4-second mark of an HTML animation example under `assets/example/` and save screenshots. Instead of jumping straight to the end, the script now advances virtual time in 100 ms increments and records a frame at each step, culminating in the 4-second capture. This mirrors the state changes an animation would experience frame by frame, which keeps lifecycle-driven UI in sync with real playback.
+The repository provides `scripts/capture-animation-screenshot.js`, which uses [Playwright](https://playwright.dev/) and Chrome DevTools Protocol virtual time to jump to the default 4-second mark of an HTML animation example under `assets/example/` and save screenshots. Instead of jumping straight to the end, the script now advances virtual time in 200 ms increments and records a frame at each step, culminating in the 4-second capture. This mirrors the state changes an animation would experience frame by frame, which keeps lifecycle-driven UI in sync with real playback.
 
 Follow these steps to configure your environment and run the script:
 
@@ -67,7 +67,7 @@ Follow these steps to configure your environment and run the script:
    ```bash
    npm run capture:animation -- animejs-virtual-time.html
    ```
-   Replace `animejs-virtual-time.html` with the HTML file you want to capture from `assets/example/`. You can also supply wildcard patterns such as `animejs-*.html` or `*.html` to capture multiple files in a single run. The script writes a series of screenshots (100 ms apart by default) such as `tmp/output/animejs-virtual-time-0000ms.png` through `tmp/output/animejs-virtual-time-4000ms.png`.
+   Replace `animejs-virtual-time.html` with the HTML file you want to capture from `assets/example/`. You can also supply wildcard patterns such as `animejs-*.html` or `*.html` to capture multiple files in a single run. The script writes a series of screenshots (200 ms apart by default) such as `tmp/output/animejs-virtual-time-0000ms.png` through `tmp/output/animejs-virtual-time-4000ms.png`.
 
 If `playwright install-deps` is not available on your platform, refer to the list of packages documented in Playwright's [system requirements guide](https://playwright.dev/docs/intro#system-requirements).
 
@@ -77,7 +77,7 @@ After following the installation steps, use the commands below to confirm your e
 
 1. Install dependencies with `npm install`.
 2. Install the Chromium browser binary with `npx playwright install chromium` (and, on Linux, system libraries via `npx playwright install-deps`).
-3. Capture an example animation with `npm run capture:animation -- animejs-virtual-time.html`. You should see output similar to `tmp/output/animejs-virtual-time-0000ms.png` through `tmp/output/animejs-virtual-time-4000ms.png`, representing the 100 ms timeline.
+3. Capture an example animation with `npm run capture:animation -- animejs-virtual-time.html`. You should see output similar to `tmp/output/animejs-virtual-time-0000ms.png` through `tmp/output/animejs-virtual-time-4000ms.png`, representing the 200 ms timeline.
 
 ## Formatting scripts
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "private": true,
   "scripts": {
     "capture:animation": "node scripts/capture-animation-screenshot.js",
-    "format": "prettier --write \"scripts/*.js\""
+    "format": "prettier --write \"scripts/*.js\"",
+    "test": "node --test"
   },
   "dependencies": {
     "playwright": "^1.43.0"

--- a/tests/capture-animation-screenshot.test.js
+++ b/tests/capture-animation-screenshot.test.js
@@ -1,0 +1,35 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  buildCaptureTimeline,
+  containsWildcards,
+  resolveAnimationPattern,
+  wildcardToRegExp,
+} = require('../scripts/capture-animation-screenshot');
+
+test('buildCaptureTimeline returns a monotonic sequence ending at the target', () => {
+  const timeline = buildCaptureTimeline(450, 200);
+  assert.deepStrictEqual(timeline, [0, 200, 400, 450]);
+});
+
+test('buildCaptureTimeline handles missing or invalid intervals by returning only the target', () => {
+  assert.deepStrictEqual(buildCaptureTimeline(400, 0), [400]);
+  assert.deepStrictEqual(buildCaptureTimeline(400, Number.NaN), [400]);
+});
+
+test('resolveAnimationPattern validates HTML filenames and strips nothing else', () => {
+  assert.strictEqual(resolveAnimationPattern(['example.htm']), 'example.htm');
+  assert.strictEqual(resolveAnimationPattern(['example.html']), 'example.html');
+  assert.throws(() => resolveAnimationPattern([]), /Expected the HTML file name/);
+});
+
+test('wildcard matching utilities respect glob semantics case-insensitively', () => {
+  assert.strictEqual(containsWildcards('demo.html'), false);
+  assert.strictEqual(containsWildcards('demo-*.html'), true);
+
+  const matcher = wildcardToRegExp('Demo-??.HTML');
+  assert.ok(matcher.test('demo-ab.html'));
+  assert.ok(matcher.test('Demo-12.htmL'));
+  assert.ok(!matcher.test('demo-abc.html'));
+});


### PR DESCRIPTION
## Summary
- prevent the RAF probe from leaving stale callbacks behind by tracking handles and clearing them after execution or cancellation
- expose capture helper utilities for reuse while only running the workflow when invoked directly, and document the 200 ms capture cadence
- add lightweight node:test coverage for the capture timeline and glob helpers plus an npm test script

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e4bb344b78832b8b0f714909988d8d