### PR TITLE
fix: reject non-finite bootstrap waits

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ DOM state as a human viewer would see at the default 4-second mark.
 
 ## Running the animation capture script
 
-The repository provides `scripts/capture-animation-screenshot.js`, which uses [Playwright](https://playwright.dev/) and Chrome DevTools Protocol virtual time to jump to the default 4-second mark of an HTML animation example under `assets/example/` and save screenshots. Instead of jumping straight to the end, the script now advances virtual time in 200 ms increments and records a frame at each step, culminating in the 4-second capture. This mirrors the state changes an animation would experience frame by frame, which keeps lifecycle-driven UI in sync with real playback.
+The repository provides `scripts/capture-animation-screenshot.js`, which uses [Playwright](https://playwright.dev/) and Chrome DevTools Protocol virtual time to jump to the default 4-second mark of an HTML animation example under `assets/example/` and saves screenshots. Instead of jumping straight to the end, the script now advances virtual time in 200 ms increments and records a frame at each step, culminating in the 4-second capture. This mirrors the state changes an animation would experience frame by frame, which keeps lifecycle-driven UI in sync with real playback.
 
 Follow these steps to configure your environment and run the script:
 
@@ -87,4 +87,4 @@ To keep code style consistent with the Prettier – Code formatter settings used
 npm run format
 ```
 
-This command applies Prettier's defaults to every file under `scripts/`, matching the formatting you would get from the VS Code extension.
+This command applies Prettier's defaults to each JavaScript file directly inside `scripts/`, matching the formatting you would get from the VS Code extension.

--- a/scripts/capture-animation-screenshot.js
+++ b/scripts/capture-animation-screenshot.js
@@ -50,7 +50,7 @@ function buildCaptureConfig(argv, env = process.env) {
 }
 
 function assertFiniteNumber(value, propertyName) {
-  if (typeof value !== "number" || Number.isNaN(value)) {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
     throw new Error(
       `Expected ${propertyName} to be a finite number. Received ${value}.`
     );
@@ -974,6 +974,7 @@ module.exports = {
   buildCaptureConfig,
   buildCaptureTimeline,
   containsWildcards,
+  validateCaptureConfig,
   resolveAnimationPattern,
   wildcardToRegExp,
 };

--- a/tests/capture-animation-screenshot.test.js
+++ b/tests/capture-animation-screenshot.test.js
@@ -5,6 +5,7 @@ const {
   buildCaptureTimeline,
   containsWildcards,
   resolveAnimationPattern,
+  validateCaptureConfig,
   wildcardToRegExp,
 } = require('../scripts/capture-animation-screenshot');
 
@@ -32,4 +33,21 @@ test('wildcard matching utilities respect glob semantics case-insensitively', ()
   assert.ok(matcher.test('demo-ab.html'));
   assert.ok(matcher.test('Demo-12.htmL'));
   assert.ok(!matcher.test('demo-abc.html'));
+});
+
+test('validateCaptureConfig rejects non-finite bootstrap waits', () => {
+  const validConfig = {
+    minInitialRealtimeWaitMs: 120,
+    maxInitialRealtimeWaitMs: 1_000,
+  };
+
+  assert.doesNotThrow(() => validateCaptureConfig(validConfig));
+  assert.throws(
+    () => validateCaptureConfig({ ...validConfig, minInitialRealtimeWaitMs: Infinity }),
+    /finite number/
+  );
+  assert.throws(
+    () => validateCaptureConfig({ ...validConfig, maxInitialRealtimeWaitMs: Infinity }),
+    /finite number/
+  );
 });


### PR DESCRIPTION
## Summary
- ensure bootstrap wait validation rejects non-finite values and make the helper testable
- clarify README wording about screenshot capture and the scope of the formatting script
- expand unit coverage to guard against Infinity wait values

## Testing
- `npm test` *(fails: Node.js/npm not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4d0cddc7c832b88c7f924fd921383