### PR TITLE
fix: handle missing Playwright dependency gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,12 +55,12 @@ Follow these steps to configure your environment and run the script:
 5. **(Optional) Tell Playwright to use a system-installed browser:**
    * To reuse an existing Chrome or Chromium installation that Playwright knows how to launch, set `PLAYWRIGHT_BROWSER_CHANNEL`. For example:
      ```bash
-     PLAYWRIGHT_BROWSER_CHANNEL=chrome npm run capture:animation
+     PLAYWRIGHT_BROWSER_CHANNEL=chrome npm run capture:animation -- animejs-virtual-time.html
      ```
      This uses the Chrome Stable channel shipped with your operating system.
    * To point at a specific executable path (for example a portable Chromium build), set `PLAYWRIGHT_CHROME_EXECUTABLE` instead:
      ```bash
-     PLAYWRIGHT_CHROME_EXECUTABLE="/usr/bin/google-chrome-stable" npm run capture:animation
+     PLAYWRIGHT_CHROME_EXECUTABLE="/usr/bin/google-chrome-stable" npm run capture:animation -- animejs-virtual-time.html
      ```
      When this variable is present the channel setting is ignored.
 6. **Run the capture script for a specific example (or pattern):**

--- a/tests/capture-animation-screenshot.test.js
+++ b/tests/capture-animation-screenshot.test.js
@@ -25,6 +25,17 @@ test('resolveAnimationPattern validates HTML filenames and strips nothing else',
   assert.throws(() => resolveAnimationPattern([]), /Expected the HTML file name/);
 });
 
+test('resolveAnimationPattern rejects paths and surplus arguments', () => {
+  assert.throws(
+    () => resolveAnimationPattern(['nested/example.html']),
+    /Provide only the HTML file name/
+  );
+  assert.throws(
+    () => resolveAnimationPattern(['example.html', 'extra.html']),
+    /unexpected extra arguments/
+  );
+});
+
 test('wildcard matching utilities respect glob semantics case-insensitively', () => {
   assert.strictEqual(containsWildcards('demo.html'), false);
   assert.strictEqual(containsWildcards('demo-*.html'), true);
@@ -49,5 +60,22 @@ test('validateCaptureConfig rejects non-finite bootstrap waits', () => {
   assert.throws(
     () => validateCaptureConfig({ ...validConfig, maxInitialRealtimeWaitMs: Infinity }),
     /finite number/
+  );
+});
+
+test('validateCaptureConfig enforces max wait not falling below the minimum', () => {
+  const baseConfig = {
+    minInitialRealtimeWaitMs: 200,
+    maxInitialRealtimeWaitMs: 400,
+  };
+
+  assert.doesNotThrow(() => validateCaptureConfig(baseConfig));
+  assert.throws(
+    () =>
+      validateCaptureConfig({
+        ...baseConfig,
+        maxInitialRealtimeWaitMs: baseConfig.minInitialRealtimeWaitMs - 1,
+      }),
+    /greater than or equal/
   );
 });


### PR DESCRIPTION
## Summary
- load Playwright lazily and provide a clear error when the dependency is missing, keeping tests runnable without the package
- document that environment variable examples still require an animation filename
- extend configuration and pattern tests for additional validation coverage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5e7661bc0832baa633324bce62859