### PR TITLE
fix: apply init scripts before page creation

### DIFF
--- a/scripts/capture-animation-screenshot.js
+++ b/scripts/capture-animation-screenshot.js
@@ -804,11 +804,12 @@ async function waitForAnimationBootstrap(page, config) {
 async function captureAnimationFile(browser, animationFile, config) {
   const targetPath = path.resolve(config.exampleDir, animationFile);
   const context = await browser.newContext({ viewport: config.viewport });
-  const page = await context.newPage();
+  let page;
 
   try {
     await injectRafProbe(context);
     await injectFrameworkPatches(context);
+    page = await context.newPage();
     const fileUrl = pathToFileURL(targetPath).href;
     await page.goto(fileUrl, { waitUntil: "load" });
 


### PR DESCRIPTION
## Summary
- ensure Playwright init scripts are registered before opening the page so they execute on the first navigation

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e5eda27f78832b89afdbbf4cd094b7