### PR TITLE
fix: support anime.js createTimeline in capture script

### DIFF
--- a/scripts/capture-animation-screenshot.js
+++ b/scripts/capture-animation-screenshot.js
@@ -341,6 +341,22 @@ const FRAMEWORK_PATCHES = [
           });
         }
 
+        if (typeof factory.createTimeline === "function") {
+          Object.defineProperty(wrapped, "createTimeline", {
+            configurable: true,
+            enumerable: true,
+            writable: true,
+            // Ensures anime.createTimeline() timelines also receive the bootstrap patch.
+            value: function createTimelineWrapper() {
+              // anime.createTimeline() was introduced in anime.js 4.x and bypasses the
+              // main factory entirely. Patch its returned timeline so virtual-time
+              // seeks remain consistent regardless of the creation helper in use.
+              const instance = factory.createTimeline.apply(factory, arguments);
+              return patchInstance(instance);
+            },
+          });
+        }
+
         return wrapped;
       };
 


### PR DESCRIPTION
## Summary
- wrap anime.js `createTimeline` so returned timelines receive the capture bootstrap patch
- restore correct virtual-time fast-forwarding for anime.js 4.x demos when capturing screenshots

## Testing
- npx playwright install chromium
- npx playwright install-deps
- npm run capture:animation -- animejs-virtual-time.html

------
https://chatgpt.com/codex/tasks/task_e_68e67db49904832b9e8d21cc85618090