### PR TITLE
docs: update README and add Chinese translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # code-play
 
-This repository contains small web examples and automation helpers.
+This repository contains small web examples and automation helpers. The
+primary utility is a Playwright-powered workflow that rewinds and fast forwards
+HTML animations to capture consistent reference frames.
 
 ## Anime.js virtual time workaround
 
@@ -10,29 +12,50 @@ flags and fires lifecycle hooks such as `begin` and `loopBegin` during those
 callbacks, so fast-forwarding directly to 4 seconds used to leave the footer
 elements hidden in `animejs-virtual-time.html`.
 
-To keep the automation generic while matching real playback, the script now
-ships with a pluggable "framework patch" registry. Each patch is injected
-before page scripts execute and activates only when its target framework is
-present. The current registry contains a lightweight anime.js interceptor that
-restores missing lifecycle hooks:
+To keep the automation generic while matching real playback, the script ships
+with a pluggable "framework patch" registry. Each patch is injected before
+page scripts execute and activates only when its target framework is present.
+The current registry contains a lightweight anime.js interceptor that restores
+missing lifecycle hooks:
 
 * A `requestAnimationFrame` probe counts initial ticks so that the automation
   waits for the first frame of real time before seizing virtual time control.
 * The interceptor wraps the global `anime` factory (and timelines it creates)
   and primes an instance's `currentTime` before the first virtual-time
-  `seek()` call. Anime.js guards most lifecycle callbacks—`begin`,
-  `loopBegin`, and even `update`/`change*`—behind the assumption that at least
-  one prior frame has advanced `currentTime` beyond zero. By simulating that
-  first frame we let anime.js run its native callback cascade in the correct
-  order, so subsequent hooks (`loopComplete`, `complete`, etc.) fire exactly as
-  they do during real playback.
+  `seek()` call. Anime.js guards most lifecycle callbacks—`begin`, `loopBegin`,
+  and even `update`/`change*`—behind the assumption that at least one prior
+  frame has advanced `currentTime` beyond zero. By simulating that first frame
+  we let anime.js run its native callback cascade in the correct order, so
+  subsequent hooks (`loopComplete`, `complete`, etc.) fire exactly as they do
+  during real playback.
 
-With these two pieces in place, virtual time captures now reproduce the same
-DOM state as a human viewer would see at the default 4-second mark.
+With these pieces in place, virtual time captures reproduce the same DOM state
+that a human viewer sees at the default 4-second mark.
+
+## Selecting animations to capture
+
+`npm run capture:animation` accepts a single HTML file name (without any
+directory separators) that must live under `assets/example/`. You can supply
+literal file names such as `animejs-virtual-time.html` or glob patterns such as
+`animejs-*.html` and `*.html`. When a glob matches multiple files the script
+captures each one sequentially using the same configuration. Supplying a path
+segment or extra arguments causes the script to abort with a validation error,
+so pass only the bare file name or pattern.
 
 ## Running the animation capture script
 
-The repository provides `scripts/capture-animation-screenshot.js`, which uses [Playwright](https://playwright.dev/) and Chrome DevTools Protocol virtual time to jump to the default 4-second mark of an HTML animation example under `assets/example/` and saves screenshots. Instead of jumping straight to the end, the script now advances virtual time in 200 ms increments and records a frame at each step, culminating in the 4-second capture. This mirrors the state changes an animation would experience frame by frame, which keeps lifecycle-driven UI in sync with real playback.
+The repository provides `scripts/capture-animation-screenshot.js`, which uses
+[Playwright](https://playwright.dev/) and Chrome DevTools Protocol virtual time
+to jump to the default 4-second mark of an HTML animation example under
+`assets/example/` and saves screenshots. Instead of jumping straight to the
+end, the script advances virtual time in 200 ms increments and records a frame
+at each step, culminating in the 4-second capture. This mirrors the state
+changes an animation would experience frame by frame, which keeps
+lifecycle-driven UI in sync with real playback. The script automatically waits
+between 120 ms and 1 s of real time for bootstrap RAF ticks before seizing
+virtual time, and it settles for an additional delay between captures (200 ms
+frames use a 50 ms real-time pause; the final frame waits 1 s) so late-arriving
+DOM updates make it into the screenshots.
 
 Follow these steps to configure your environment and run the script:
 
@@ -67,17 +90,38 @@ Follow these steps to configure your environment and run the script:
    ```bash
    npm run capture:animation -- animejs-virtual-time.html
    ```
-   Replace `animejs-virtual-time.html` with the HTML file you want to capture from `assets/example/`. You can also supply wildcard patterns such as `animejs-*.html` or `*.html` to capture multiple files in a single run. The script writes a series of screenshots (200 ms apart by default) such as `tmp/output/animejs-virtual-time-0000ms.png` through `tmp/output/animejs-virtual-time-4000ms.png`.
+   Replace `animejs-virtual-time.html` with the HTML file you want to capture
+   from `assets/example/`. You can also supply wildcard patterns such as
+   `animejs-*.html` or `*.html` to capture multiple files in a single run. The
+   script refuses absolute or relative paths outside the example directory. The
+   script writes a series of screenshots (200 ms apart by default) such as
+   `tmp/output/animejs-virtual-time-0000ms.png` through
+   `tmp/output/animejs-virtual-time-4000ms.png`. The output directory is created
+   on demand, and each file name is sanitized to avoid leaking directory
+   separators into the `tmp/output/` tree.
 
 If `playwright install-deps` is not available on your platform, refer to the list of packages documented in Playwright's [system requirements guide](https://playwright.dev/docs/intro#system-requirements).
 
 ## Verifying your setup
 
-After following the installation steps, use the commands below to confirm your environment is ready:
+After following the installation steps, use the commands below to confirm your
+environment is ready:
 
 1. Install dependencies with `npm install`.
-2. Install the Chromium browser binary with `npx playwright install chromium` (and, on Linux, system libraries via `npx playwright install-deps`).
-3. Capture an example animation with `npm run capture:animation -- animejs-virtual-time.html`. You should see output similar to `tmp/output/animejs-virtual-time-0000ms.png` through `tmp/output/animejs-virtual-time-4000ms.png`, representing the 200 ms timeline.
+2. Install the Chromium browser binary with `npx playwright install chromium`
+   (and, on Linux, system libraries via `npx playwright install-deps`).
+3. Capture an example animation with
+   `npm run capture:animation -- animejs-virtual-time.html`. You should see
+   output similar to `tmp/output/animejs-virtual-time-0000ms.png` through
+   `tmp/output/animejs-virtual-time-4000ms.png`, representing the 200 ms
+   timeline. When the run succeeds the script prints the absolute paths to each
+   saved file. Failures include actionable hints, such as installing missing
+   browser binaries or verifying that the target HTML file exists.
+
+## Additional resources
+
+* [README.zh-CN.md](README.zh-CN.md) — Simplified Chinese translation of this
+  guide.
 
 ## Formatting scripts
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,69 @@
+# code-play
+
+本仓库收集了一些小型 Web 示例和自动化工具，核心是一个借助 Playwright 的工作流，用于在 HTML 动画中快退和快进以捕获一致的参考帧。
+
+## Anime.js 虚拟时间兼容补丁
+
+Playwright 捕获脚本运行在 Chrome 的虚拟时间域中，该模式会跳过 `requestAnimationFrame` 回调。Anime.js 通常会在这些回调中切换 `began` 标记并触发 `begin`、`loopBegin` 等生命周期钩子，因此如果直接快进到 4 秒，`animejs-virtual-time.html` 页脚元素会保持隐藏状态。
+
+为在保持自动化通用性的同时复现真实播放效果，脚本内置了一个可插拔的“框架补丁”注册表。每个补丁都会在页面脚本执行前注入，只在检测到目标框架时启用。当前注册表包含一个轻量的 anime.js 拦截器，用来恢复缺失的生命周期钩子：
+
+* `requestAnimationFrame` 探针会统计初始 tick，确保自动化在取得首帧真实时间之前不会接管虚拟时间控制。
+* 拦截器包装全局 `anime` 工厂（以及它创建的时间线），并在第一次虚拟时间 `seek()` 调用前预热实例的 `currentTime`。Anime.js 默认认为至少要有一个前置帧将 `currentTime` 推过零点才会触发大多数生命周期回调——包括 `begin`、`loopBegin`、`update` 和 `change*`。通过模拟该首帧，脚本让 anime.js 按正确顺序运行原生回调级联，后续钩子（`loopComplete`、`complete` 等）会像实时播放一样被触发。
+
+依靠这些机制，虚拟时间捕获现在可以在默认的 4 秒时间点重现与真人观察者一致的 DOM 状态。
+
+## 选择要捕获的动画
+
+`npm run capture:animation` 接受一个位于 `assets/example/` 下的 HTML 文件名（不包含目录分隔符）。可以传入诸如 `animejs-virtual-time.html` 的具体文件名，或 `animejs-*.html`、`*.html` 这类通配模式。若通配符匹配到多个文件，脚本会使用相同配置顺序捕获。传入路径片段或额外参数会触发验证错误，因此只需提供文件名或模式即可。
+
+## 运行动画捕获脚本
+
+仓库提供的 `scripts/capture-animation-screenshot.js` 使用 [Playwright](https://playwright.dev/) 与 Chrome DevTools Protocol 虚拟时间，在 `assets/example/` 中的 HTML 动画示例里跳转到默认的 4 秒时间点并保存截图。脚本不会一次跳到终点，而是按 200 ms 的步长推进虚拟时间，每个时间点都会记录一帧，最终得到 4 秒的图像。这种逐帧推进与真实播放过程相匹配，使依赖生命周期的 UI 能保持同步。脚本会在接管虚拟时间前自动等待 120 ms 到 1 s 的真实时间，以获取足够的 RAF 引导 tick；在截图之间还会留出额外的真实时间（常规帧等待 50 ms，最终帧等待 1 s），确保延迟到达的 DOM 更新被写入图像。
+
+配置与运行步骤如下：
+
+1. **安装 Node.js 18+**：脚本已在现代 LTS 版本中验证，可通过 `node --version` 检查版本。
+2. **安装依赖：**
+   ```bash
+   npm install
+   ```
+   该命令会安装 `package.json` 中声明的 Playwright。
+3. **安装所需的浏览器二进制：**
+   ```bash
+   npx playwright install chromium
+   ```
+   脚本使用 Chromium 渲染动画。
+4. **在 Linux 上安装 Chromium 依赖：**
+   ```bash
+   npx playwright install-deps
+   ```
+   精简的 Linux 环境可通过此命令安装 Chromium 需要的系统库；macOS 与 Windows 可跳过。
+5. **（可选）让 Playwright 使用系统浏览器：**
+   * 若要复用 Playwright 已知的 Chrome/Chromium 安装，可设置 `PLAYWRIGHT_BROWSER_CHANNEL`。例如：
+     ```bash
+     PLAYWRIGHT_BROWSER_CHANNEL=chrome npm run capture:animation -- animejs-virtual-time.html
+     ```
+     这样会使用操作系统提供的 Chrome Stable 渠道。
+   * 若要指定某个可执行文件路径（例如便携版 Chromium），可设置 `PLAYWRIGHT_CHROME_EXECUTABLE`：
+     ```bash
+     PLAYWRIGHT_CHROME_EXECUTABLE="/usr/bin/google-chrome-stable" npm run capture:animation -- animejs-virtual-time.html
+     ```
+     当该变量存在时，`PLAYWRIGHT_BROWSER_CHANNEL` 会被忽略。
+6. **运行捕获脚本（文件名或模式）：**
+   ```bash
+   npm run capture:animation -- animejs-virtual-time.html
+   ```
+   将 `animejs-virtual-time.html` 替换为 `assets/example/` 中想要捕获的 HTML 文件。也可以使用 `animejs-*.html` 或 `*.html` 这类通配模式批量捕获。脚本会拒绝指向示例目录以外的绝对或相对路径。截图文件（默认每帧间隔 200 ms）会自动写入 `tmp/output/`，命名形式如 `tmp/output/animejs-virtual-time-0000ms.png` 至 `tmp/output/animejs-virtual-time-4000ms.png`。输出目录会按需创建，文件名会被清理以避免目录分隔符泄漏到 `tmp/output/` 结构中。
+
+## 验证环境
+
+完成上述安装后，可通过以下命令确认环境已就绪：
+
+1. 执行 `npm install` 安装依赖。
+2. 运行 `npx playwright install chromium` 安装 Chromium（Linux 环境还需执行 `npx playwright install-deps` 安装系统库）。
+3. 使用 `npm run capture:animation -- animejs-virtual-time.html` 捕获示例动画。成功时可在控制台看到保存的绝对路径，以及 `tmp/output/animejs-virtual-time-0000ms.png` 至 `tmp/output/animejs-virtual-time-4000ms.png` 等文件。若流程失败，脚本会给出可操作的提示，例如安装缺失的浏览器或检查目标 HTML 文件是否存在。
+
+## 其他资源
+
+* [README.md](README.md) — 英文版使用指南。


### PR DESCRIPTION
## Summary
- expand the English README with details on animation selection, virtual-time delays, and troubleshooting output
- add a Simplified Chinese translation of the README for contributors who prefer Mandarin documentation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e72a62dd30832bad9d8cf1c0ad026e