### PR TITLE
fix: validate example directory paths

### DIFF
--- a/scripts/capture-animation-screenshot.js
+++ b/scripts/capture-animation-screenshot.js
@@ -483,8 +483,9 @@ const FRAMEWORK_PATCHES = [
 
 // Confirms the example directory exists so captures have input files to process.
 async function ensureDirectoryAvailable(directoryPath) {
+  let stats;
   try {
-    await fs.access(directoryPath);
+    stats = await fs.stat(directoryPath);
   } catch (error) {
     if (error?.code === "ENOENT") {
       throw new Error(
@@ -493,6 +494,12 @@ async function ensureDirectoryAvailable(directoryPath) {
     }
 
     throw error;
+  }
+
+  if (!stats.isDirectory()) {
+    throw new Error(
+      `Expected "${directoryPath}" to be a directory. Add animation examples under assets/example/.`
+    );
   }
 }
 
@@ -1302,6 +1309,7 @@ module.exports = {
   buildCaptureConfig,
   buildCaptureTimeline,
   containsWildcards,
+  ensureDirectoryAvailable,
   validateCaptureConfig,
   resolveAnimationPattern,
   wildcardToRegExp,

--- a/tests/capture-animation-screenshot.test.js
+++ b/tests/capture-animation-screenshot.test.js
@@ -1,9 +1,13 @@
 const { test } = require('node:test');
 const assert = require('node:assert/strict');
+const fs = require('node:fs/promises');
+const os = require('node:os');
+const path = require('node:path');
 
 const {
   buildCaptureTimeline,
   containsWildcards,
+  ensureDirectoryAvailable,
   resolveAnimationPattern,
   validateCaptureConfig,
   wildcardToRegExp,
@@ -77,5 +81,20 @@ test('validateCaptureConfig enforces max wait not falling below the minimum', ()
         maxInitialRealtimeWaitMs: baseConfig.minInitialRealtimeWaitMs - 1,
       }),
     /greater than or equal/
+  );
+});
+
+test('ensureDirectoryAvailable rejects paths that are not directories', async (t) => {
+  const tmpRoot = await fs.mkdtemp(path.join(os.tmpdir(), 'capture-test-'));
+  const filePath = path.join(tmpRoot, 'example.html');
+  await fs.writeFile(filePath, '<html></html>');
+
+  t.after(async () => {
+    await fs.rm(tmpRoot, { recursive: true, force: true });
+  });
+
+  await assert.rejects(
+    ensureDirectoryAvailable(filePath),
+    /to be a directory/,
   );
 });


### PR DESCRIPTION
## Summary
- ensure the capture workflow rejects example paths that are not directories
- add a regression test covering directory validation failures

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_6900627eb300832b99f4bd2bf41b03e3